### PR TITLE
fix css to display navigation options inline

### DIFF
--- a/app/assets/stylesheets/general.css.scss
+++ b/app/assets/stylesheets/general.css.scss
@@ -293,7 +293,7 @@ h4 {
   display: block;
   font-family: 'Dosis Regular' , sans-serif;
   font-style: normal;
-  font-size: 18px;
+  font-size: 16px;
   color: #ffffff;
   line-height: 38px;
   min-width: 36px;


### PR DESCRIPTION
fixed font size for nav .select a to display navbar options inline

Before:

![before_fix](https://cloud.githubusercontent.com/assets/12286202/23043482/6c22da18-f46a-11e6-84f9-0eb345127745.JPG)

After:

![after_fix](https://cloud.githubusercontent.com/assets/12286202/23043506/841a7860-f46a-11e6-8edd-67c13b3815b2.JPG)

PS: minor fix hence didn't run ci tests
