### PR TITLE
migrations rails version issue

### DIFF
--- a/db/migrate/20200827062117_create_recurring_frequencies.rb
+++ b/db/migrate/20200827062117_create_recurring_frequencies.rb
@@ -1,4 +1,4 @@
-class CreateRecurringFrequencies < ActiveRecord::Migration
+class CreateRecurringFrequencies < ActiveRecord::Migration[6.0]
   def change
     create_table :recurring_frequencies do |t|
       t.integer :number_of_days

--- a/db/migrate/20200831092458_add_role_to_clients.rb
+++ b/db/migrate/20200831092458_add_role_to_clients.rb
@@ -1,4 +1,4 @@
-class AddRoleToClients < ActiveRecord::Migration
+class AddRoleToClients < ActiveRecord::Migration[6.0]
   def change
     add_reference :clients, :role, index: true, foreign_key: true
   end

--- a/db/migrate/20200831092943_add_column_for_client_to_role.rb
+++ b/db/migrate/20200831092943_add_column_for_client_to_role.rb
@@ -1,4 +1,4 @@
-class AddColumnForClientToRole < ActiveRecord::Migration
+class AddColumnForClientToRole < ActiveRecord::Migration[6.0]
   def change
     add_column :roles, :for_client, :boolean, default: false
   end

--- a/db/migrate/20200909112820_add_fields_to_recurring_schedule.rb
+++ b/db/migrate/20200909112820_add_fields_to_recurring_schedule.rb
@@ -1,4 +1,4 @@
-class AddFieldsToRecurringSchedule < ActiveRecord::Migration
+class AddFieldsToRecurringSchedule < ActiveRecord::Migration[6.0]
   def change
     add_column :recurring_schedules, :frequency_repetition, :integer
     add_column :recurring_schedules, :frequency_type, :string

--- a/db/migrate/20200911081826_add_default_note_and_show_default_note.rb
+++ b/db/migrate/20200911081826_add_default_note_and_show_default_note.rb
@@ -1,4 +1,4 @@
-class AddDefaultNoteAndShowDefaultNote < ActiveRecord::Migration
+class AddDefaultNoteAndShowDefaultNote < ActiveRecord::Migration[6.0]
   def change
     add_column :companies, :default_note, :string
   end

--- a/db/migrate/20200911131456_add_default_due_date_periodo_companies.rb
+++ b/db/migrate/20200911131456_add_default_due_date_periodo_companies.rb
@@ -1,4 +1,4 @@
-class AddDefaultDueDatePeriodoCompanies < ActiveRecord::Migration
+class AddDefaultDueDatePeriodoCompanies < ActiveRecord::Migration[6.0]
   def change
     add_column :companies, :due_date_period, :integer
   end

--- a/db/migrate/20210126104534_add_deleteable_to_roles.rb
+++ b/db/migrate/20210126104534_add_deleteable_to_roles.rb
@@ -1,4 +1,4 @@
-class AddDeleteableToRoles < ActiveRecord::Migration
+class AddDeleteableToRoles < ActiveRecord::Migration[6.0]
   def change
     add_column :roles, :deletable, :boolean, default: true
   end


### PR DESCRIPTION
Running the migrations would yield following error:
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for